### PR TITLE
Listing and changing the preferred input

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ var AudioRecorder = {
       OutputFormat: 'mpeg_4',
       MeteringEnabled: false,
       MeasurementMode: false,
-      AudioEncodingBitRate: 32000
+      AudioEncodingBitRate: 32000,
+      preferredInput: null
     };
 
     var recordingOptions = {...defaultOptions, ...options};
@@ -52,7 +53,8 @@ var AudioRecorder = {
         recordingOptions.AudioQuality,
         recordingOptions.AudioEncoding,
         recordingOptions.MeteringEnabled,
-        recordingOptions.MeasurementMode
+        recordingOptions.MeasurementMode,
+        recordingOptions.preferredInput
       );
     } else {
       return AudioRecorderManager.prepareRecordingAtPath(path, recordingOptions);
@@ -66,6 +68,9 @@ var AudioRecorder = {
   },
   stopRecording: function() {
     return AudioRecorderManager.stopRecording();
+  },
+  getAvailableInputs: function() {
+    return AudioRecorderManager.getAvailableInputs();
   },
   checkAuthorizationStatus: AudioRecorderManager.checkAuthorizationStatus,
   requestAuthorization: AudioRecorderManager.requestAuthorization,

--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -249,13 +249,13 @@ RCT_EXPORT_METHOD(checkAuthorizationStatus:(RCTPromiseResolveBlock)resolve rejec
 RCT_EXPORT_METHOD(requestAuthorization:(RCTPromiseResolveBlock)resolve
                   rejecter:(__unused RCTPromiseRejectBlock)reject)
 {
-    [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
-        if(granted) {
-            resolve(@YES);
-        } else {
-            resolve(@NO);
-        }
-    }];
+  [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
+    if(granted) {
+      resolve(@YES);
+    } else {
+      resolve(@NO);
+    }
+  }];
 }
 
 RCT_EXPORT_METHOD(getAvailableInputs:(RCTPromiseResolveBlock)resolve

--- a/ios/AudioRecorderManager.m
+++ b/ios/AudioRecorderManager.m
@@ -89,7 +89,7 @@ RCT_EXPORT_MODULE();
   return basePath;
 }
 
-RCT_EXPORT_METHOD(prepareRecordingAtPath:(NSString *)path sampleRate:(float)sampleRate channels:(nonnull NSNumber *)channels quality:(NSString *)quality encoding:(NSString *)encoding meteringEnabled:(BOOL)meteringEnabled measurementMode:(BOOL)measurementMode)
+RCT_EXPORT_METHOD(prepareRecordingAtPath:(NSString *)path sampleRate:(float)sampleRate channels:(nonnull NSNumber *)channels quality:(NSString *)quality encoding:(NSString *)encoding meteringEnabled:(BOOL)meteringEnabled measurementMode:(BOOL)measurementMode preferredInput:(NSString *)preferredInput)
 {
   _prevProgressUpdateTime = nil;
   [self stopProgressTimer];
@@ -170,6 +170,15 @@ RCT_EXPORT_METHOD(prepareRecordingAtPath:(NSString *)path sampleRate:(float)samp
 
   _recordSession = [AVAudioSession sharedInstance];
 
+    
+  if (preferredInput) {
+    for (AVAudioSessionPortDescription *desc in [_recordSession availableInputs]) {
+      if ([preferredInput isEqualToString:desc.UID]) {
+        [_recordSession setPreferredInput:desc error:nil];
+      }
+    }
+  }
+
   if (_measurementMode) {
       [_recordSession setCategory:AVAudioSessionCategoryRecord error:nil];
       [_recordSession setMode:AVAudioSessionModeMeasurement error:nil];
@@ -240,13 +249,36 @@ RCT_EXPORT_METHOD(checkAuthorizationStatus:(RCTPromiseResolveBlock)resolve rejec
 RCT_EXPORT_METHOD(requestAuthorization:(RCTPromiseResolveBlock)resolve
                   rejecter:(__unused RCTPromiseRejectBlock)reject)
 {
-  [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
-    if(granted) {
-      resolve(@YES);
-    } else {
-      resolve(@NO);
+    [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
+        if(granted) {
+            resolve(@YES);
+        } else {
+            resolve(@NO);
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(getAvailableInputs:(RCTPromiseResolveBlock)resolve
+                  rejecter:(__unused RCTPromiseRejectBlock)reject)
+{
+    NSDictionary *const AudioRecorderPortTypes = [[NSDictionary alloc] initWithObjectsAndKeys:@"builtInMic",AVAudioSessionPortBuiltInMic,@"bluetoothHFP",AVAudioSessionPortBluetoothHFP,@"bluetoothA2DP",AVAudioSessionPortBluetoothA2DP,@"bluetoothLE",AVAudioSessionPortBluetoothLE,@"lineIn",AVAudioSessionPortLineIn,@"airPlay",AVAudioSessionPortAirPlay,@"carAudio",AVAudioSessionPortCarAudio,@"USBAudio",AVAudioSessionPortUSBAudio,@"headsetMic",AVAudioSessionPortHeadsetMic,@"builtInReceiver",AVAudioSessionPortBuiltInReceiver, nil];
+    
+    // Enable bluetooth
+    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryRecord withOptions:kAudioSessionProperty_OverrideCategoryEnableBluetoothInput error:nil];
+    
+    NSArray<AVAudioSessionPortDescription *> *availableInputs = [[AVAudioSession sharedInstance] availableInputs];
+    
+    NSMutableArray *result = [NSMutableArray array];
+    
+    for (AVAudioSessionPortDescription *desc in availableInputs) {
+        [result addObject:@{
+            @"id": desc.UID,
+            @"type": AudioRecorderPortTypes[desc.portType],
+            @"name": desc.portName
+        }];
     }
-  }];
+
+    resolve(result);
 }
 
 - (NSString *)getPathForDirectory:(int)directory


### PR DESCRIPTION
Here's how you can use it:

```js
const path = `${AudioUtils.DocumentDirectoryPath}/file.aac`;

const inputs = await AudioRecorder.getAvailableInputs();

console.log(inputs);

for (let input of inputs) {
  if (/LOTUS/.test(input.name)) {
    await AudioRecorder.prepareRecordingAtPath(path, {
      preferredInput: input.id,
      // ... other options such as sample rate, etc.
    });
  }
}
```

The `AudioRecorder.getAvailableInputs()` returns a list of available recording devices like this:
```
[ { id: 'Built-In Microphone',
    type: 'builtInMic',
    name: 'iPhone Microphone' },
  { id: 'D4:F5:11:50:8A:22',
    type: 'bluetoothHFP',
    name: 'LOTUS 1.7-12311' } ]
```